### PR TITLE
Various improvements to cpufreq-governor and I/O-scheduler

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -242,7 +242,7 @@ on property:sys.io.scheduler=row
     write /sys/block/mmcblk0/queue/nr_requests 128
 
     # Optimal read ahead value
-    write /sys/block/mmcblk0/queue/read_ahead_kb 1024
+    write /sys/block/mmcblk0/queue/read_ahead 2048
 
     # Tag as non rotational devices
     write /sys/block/mmcblk0/queue/rotational 0

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -238,7 +238,6 @@ on property:sys.io.scheduler=row
     write /sys/block/mmcblk0/queue/iosched/rd_idle_data 10
     write /sys/block/mmcblk0/queue/iosched/rd_idle_data_freq 25
 
-on enable-storage-tweaks
     # Balancing the write queueing for less latency
     write /sys/block/mmcblk0/queue/nr_requests 128
 
@@ -266,11 +265,20 @@ on property:dev.bootcomplete=1
     # IO Scheduler is being set
     setprop sys.io.scheduler row
 
-    # Internal memory tweaks 
-    trigger enable-storage-tweaks
-
     # Android memory management tweaks
-    write /sys/module/lowmemorykiller/parameters/debug_level 0
     write /sys/module/lowmemorykiller/parameters/lmk_fast_run 0
     write /proc/sys/vm/oom_dump_tasks 0
     write /proc/sys/vm/page-cluster 0
+
+    ## Please comment these params out for kernel debugging ##
+    # Turn off debugging for certain modules
+    write /sys/module/kernel/parameters/initcall_debug 0
+    write /sys/module/lowmemorykiller/parameters/debug_level 0
+    write /sys/module/earlysuspend/parameters/debug_mask 0
+    write /sys/module/alarm/parameters/debug_mask 0
+    write /sys/module/alarm_dev/parameters/debug_mask 0
+    write /sys/module/binder/parameters/debug_mask 0
+    write /sys/module/xt_qtaguid/parameters/debug_mask 0
+
+    # Disable kernel logging
+    write /sys/kernel/printk_mode/printk_mode 0

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -224,8 +224,9 @@ on property:init.svc.recovery=running
 on property:sys.io.scheduler=row
     # Create queue entry for row-iosched to apply the tweaks
     write /sys/block/mmcblk0/queue/scheduler row
+    write /sys/block/mmcblk1/queue/scheduler row
 
-    # Tweaks for row-iosched 
+    # Tweaks for row-iosched (internal mmc-flash)
     write /sys/block/mmcblk0/queue/iosched/hp_read_quantum 100          
     write /sys/block/mmcblk0/queue/iosched/hp_swrite_quantum 5
     write /sys/block/mmcblk0/queue/iosched/rp_read_quantum 75
@@ -238,26 +239,48 @@ on property:sys.io.scheduler=row
     write /sys/block/mmcblk0/queue/iosched/rd_idle_data 10
     write /sys/block/mmcblk0/queue/iosched/rd_idle_data_freq 25
 
+    # Tweaks for row-iosched (external sd-card)
+    write /sys/block/mmcblk1/queue/iosched/hp_read_quantum 100          
+    write /sys/block/mmcblk1/queue/iosched/hp_swrite_quantum 5
+    write /sys/block/mmcblk1/queue/iosched/rp_read_quantum 75
+    write /sys/block/mmcblk1/queue/iosched/rp_swrite_quantum 4
+    write /sys/block/mmcblk1/queue/iosched/rp_write_quantum 4
+    write /sys/block/mmcblk1/queue/iosched/lp_read_quantum 3
+    write /sys/block/mmcblk1/queue/iosched/lp_swrite_quantum 2
+    write /sys/block/mmcblk1/queue/iosched/read_idle 10
+    write /sys/block/mmcblk1/queue/iosched/read_idle_freq 25
+    write /sys/block/mmcblk1/queue/iosched/rd_idle_data 10
+    write /sys/block/mmcblk1/queue/iosched/rd_idle_data_freq 25
+
     # Balancing the write queueing for less latency
     write /sys/block/mmcblk0/queue/nr_requests 128
+    write /sys/block/mmcblk1/queue/nr_requests 128
 
-    # Optimal read ahead value
-    write /sys/block/mmcblk0/queue/read_ahead 2048
+    # Optimal read ahead value for 32GB storage
+    write /sys/block/mmcblk0/queue/read_ahead_kb 2048
+    write /sys/block/mmcblk0/bdi/read_ahead_kb 2048
+    write /sys/block/mmcblk1/queue/read_ahead_kb 2048
+    write /sys/block/mmcblk1/bdi/read_ahead_kb 2048
 
     # Tag as non rotational devices
     write /sys/block/mmcblk0/queue/rotational 0
+    write /sys/block/mmcblk1/queue/rotational 0
 
     # Disable iostats to reduce overhead
     write /sys/block/mmcblk0/queue/iostats 0
+    write /sys/block/mmcblk1/queue/iostats 0
 
     # Disable random, this is important for eMMC
     write /sys/block/mmcblk0/queue/add_random 0
+    write /sys/block/mmcblk1/queue/add_random 0
 
     # Merge affinity to let it freely finish on any thread
     write /sys/block/mmcblk0/queue/rq_affinity 0
+    write /sys/block/mmcblk1/queue/rq_affinity 0
 
     # Setting minimum ratio of caching for QoS
     write /sys/block/mmcblk0/bdi/min_ratio 5
+    write /sys/block/mmcblk1/bdi/min_ratio 5
 
 on property:dev.bootcomplete=1
     trigger enable-low-power

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -197,4 +197,4 @@ on property:init.svc.recovery=running
 on property:dev.bootcomplete=1
     trigger enable-low-power
 
-    setprop sys.io.scheduler "bfq"
+    setprop sys.io.scheduler "row"

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -221,13 +221,11 @@ on charger
 on property:init.svc.recovery=running
     trigger enable-low-power
 
-on property:dev.bootcomplete=1
-    trigger enable-low-power
+on property:sys.io.scheduler=row
+    # Create queue entry for row-iosched to apply the tweaks
+    write /sys/block/mmcblk0/queue/scheduler row
 
-    # Enable ROW-iosched
-    setprop sys.io.scheduler "row"
-
-    # Tweaks for ROW-iosched 
+    # Tweaks for row-iosched 
     write /sys/block/mmcblk0/queue/iosched/hp_read_quantum 100          
     write /sys/block/mmcblk0/queue/iosched/hp_swrite_quantum 5
     write /sys/block/mmcblk0/queue/iosched/rp_read_quantum 75
@@ -239,3 +237,40 @@ on property:dev.bootcomplete=1
     write /sys/block/mmcblk0/queue/iosched/read_idle_freq 25
     write /sys/block/mmcblk0/queue/iosched/rd_idle_data 10
     write /sys/block/mmcblk0/queue/iosched/rd_idle_data_freq 25
+
+on enable-storage-tweaks
+    # Balancing the write queueing for less latency
+    write /sys/block/mmcblk0/queue/nr_requests 128
+
+    # Optimal read ahead value
+    write /sys/block/mmcblk0/queue/read_ahead_kb 1024
+
+    # Tag as non rotational devices
+    write /sys/block/mmcblk0/queue/rotational 0
+
+    # Disable iostats to reduce overhead
+    write /sys/block/mmcblk0/queue/iostats 0
+
+    # Disable random, this is important for eMMC
+    write /sys/block/mmcblk0/queue/add_random 0
+
+    # Merge affinity to let it freely finish on any thread
+    write /sys/block/mmcblk0/queue/rq_affinity 0
+
+    # Setting minimum ratio of caching for QoS
+    write /sys/block/mmcblk0/bdi/min_ratio 5
+
+on property:dev.bootcomplete=1
+    trigger enable-low-power
+
+    # IO Scheduler is being set
+    setprop sys.io.scheduler row
+
+    # Internal memory tweaks 
+    trigger enable-storage-tweaks
+
+    # Android memory management tweaks
+    write /sys/module/lowmemorykiller/parameters/debug_level 0
+    write /sys/module/lowmemorykiller/parameters/lmk_fast_run 0
+    write /proc/sys/vm/oom_dump_tasks 0
+    write /proc/sys/vm/page-cluster 0

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -22,6 +22,8 @@ on boot
 
 on enable-low-power
     # HMP scheduler (big.Little cluster related) settings
+    write /proc/sys/kernel/sched_upmigrate_min_nice 15
+    write /proc/sys/kernel/sched_upmigrate 87
     write /proc/sys/kernel/sched_downmigrate 85
 
     write /proc/sys/kernel/sched_window_stats_policy 2
@@ -51,9 +53,11 @@ on enable-low-power
     write /sys/devices/soc.0/qcom,bcl.55/hotplug_soc_mask 0
     write /sys/devices/soc.0/qcom,bcl.55/mode "enable"
 
-    # Enable governor for LITTLE CPUs for 8976 (perf cluster) 
+    # Enable governor for Little CPUs for 8976 (perf cluster) 
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
+
+    # Tweaks for interactive-governor (Little)
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 40000
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 90
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
@@ -63,9 +67,11 @@ on enable-low-power
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 20000
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 400000
 
-    # Enable governor for Big CPUs for 8976 (power cluster) 
+    # Enable governor for BIG CPUs for 8976 (power cluster) 
     write /sys/devices/system/cpu/cpu4/online 1
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "interactive"
+
+    # Tweaks for interactive-governor (BIG)
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/above_hispeed_delay 40000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 93
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate 20000
@@ -94,8 +100,6 @@ on enable-low-power
     # set cpu_boost parameters for 8976
     write /sys/module/cpu_boost/parameters/input_boost_freq "0:1017600 1:0 2:0 3:0 4:0 5:0 6:0 7:0"
     write /sys/module/cpu_boost/parameters/input_boost_ms 200
-    write /proc/sys/kernel/sched_upmigrate_min_nice 15
-    write /proc/sys/kernel/sched_upmigrate 87
 
     # set (super) packing parameters for 8976
     write /sys/devices/system/cpu/cpu0/sched_mostly_idle_freq 400000
@@ -220,4 +224,18 @@ on property:init.svc.recovery=running
 on property:dev.bootcomplete=1
     trigger enable-low-power
 
+    # Enable ROW-iosched
     setprop sys.io.scheduler "row"
+
+    # Tweaks for ROW-iosched 
+    write /sys/block/mmcblk0/queue/iosched/hp_read_quantum 100          
+    write /sys/block/mmcblk0/queue/iosched/hp_swrite_quantum 5
+    write /sys/block/mmcblk0/queue/iosched/rp_read_quantum 75
+    write /sys/block/mmcblk0/queue/iosched/rp_swrite_quantum 4
+    write /sys/block/mmcblk0/queue/iosched/rp_write_quantum 4
+    write /sys/block/mmcblk0/queue/iosched/lp_read_quantum 3
+    write /sys/block/mmcblk0/queue/iosched/lp_swrite_quantum 2
+    write /sys/block/mmcblk0/queue/iosched/read_idle 10
+    write /sys/block/mmcblk0/queue/iosched/read_idle_freq 25
+    write /sys/block/mmcblk0/queue/iosched/rd_idle_data 10
+    write /sys/block/mmcblk0/queue/iosched/rd_idle_data_freq 25

--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -22,7 +22,6 @@ on boot
 
 on enable-low-power
     # HMP scheduler (big.Little cluster related) settings
-    write /proc/sys/kernel/sched_upmigrate 95
     write /proc/sys/kernel/sched_downmigrate 85
 
     write /proc/sys/kernel/sched_window_stats_policy 2
@@ -52,31 +51,55 @@ on enable-low-power
     write /sys/devices/soc.0/qcom,bcl.55/hotplug_soc_mask 0
     write /sys/devices/soc.0/qcom,bcl.55/mode "enable"
 
-    # Enable governor for power cluster
+    # Enable governor for LITTLE CPUs for 8976 (perf cluster) 
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 80
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 40000
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 90
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 0
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 40000
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 691200
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 59000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1305600
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "1 691200:80"
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq 1017600
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 1
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "87 400000:93 1017600:95 1190400:95"
+    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 20000
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 400000
 
-    # Enable governor for perf cluster
+    # Enable governor for Big CPUs for 8976 (power cluster) 
     write /sys/devices/system/cpu/cpu4/online 1
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "interactive"
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 85
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/above_hispeed_delay 40000
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 93
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate 20000
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/io_is_busy 0
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time 40000
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/sampling_down_factor 40000
-    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 883200
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/hispeed_freq 998400
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/io_is_busy 1
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads "87 400000:93 998400:95 1190400:95 1382400:97" 
+    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time 20000
+    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 400000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/max_freq_hysteresis 60000
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/hispeed_freq 1382400
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/above_hispeed_delay "19000 1382400:39000"
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads "85 1382400:90 1747200:80"
+
+    # Configure core_ctl for 8976
+    write /sys/devices/system/cpu/cpu0/core_ctl/not_preferred "1 0 1 0"
+    write /sys/devices/system/cpu/cpu0/core_ctl/busy_up_thres 78
+    write /sys/devices/system/cpu/cpu0/core_ctl/busy_down_thres 55
+    write /sys/devices/system/cpu/cpu0/core_ctl/min_cpus 2
+    write /sys/devices/system/cpu/cpu0/core_ctl/max_cpus 4
+    write /sys/devices/system/cpu/cpu4/core_ctl/not_preferred "1 0 1 0"
+    write /sys/devices/system/cpu/cpu4/core_ctl/min_cpus 2
+    write /sys/devices/system/cpu/cpu4/core_ctl/max_cpus 4
+    write /sys/devices/system/cpu/cpu4/core_ctl/busy_up_thres 78
+    write /sys/devices/system/cpu/cpu4/core_ctl/busy_down_thres 55
+    write /sys/devices/system/cpu/cpu4/core_ctl/offline_delay_ms 200
+    write /sys/devices/system/cpu/cpu4/core_ctl/task_thres 4
+    write /sys/devices/system/cpu/cpu4/core_ctl/is_big_cluster 1
+
+    # set cpu_boost parameters for 8976
+    write /sys/module/cpu_boost/parameters/input_boost_freq "0:1017600 1:0 2:0 3:0 4:0 5:0 6:0 7:0"
+    write /sys/module/cpu_boost/parameters/input_boost_ms 200
+    write /proc/sys/kernel/sched_upmigrate_min_nice 15
+    write /proc/sys/kernel/sched_upmigrate 87
+
+    # set (super) packing parameters for 8976
+    write /sys/devices/system/cpu/cpu0/sched_mostly_idle_freq 400000
+    write /sys/devices/system/cpu/cpu4/sched_mostly_idle_freq 400000
 
     # HMP Task packing settings for 8976
     write /proc/sys/kernel/sched_small_task 30


### PR DESCRIPTION
- Improved tweaking for interactive-governor 
- Use ROW I/O-scheduler by default
- Added extensive tweaks to ROW I/O-scheduler
- Added general storage-performance tweaks (For internal flash and SD-Card)

- New build with these changes got tested by me on my T813